### PR TITLE
Swift Data Repository imrpovments

### DIFF
--- a/Sources/Protocols/Repository.swift
+++ b/Sources/Protocols/Repository.swift
@@ -65,6 +65,7 @@ public protocol AsyncPredicableReadableRepository<PersistibleElement, ResultElem
     associatedtype PersistibleElement: Equatable
     associatedtype ResultElement: Equatable, Sendable
     func find(predicate: Predicate<PersistibleElement>, sortBy: SortDescriptor<PersistibleElement>?) async -> [ResultElement]
+    func findFirst(predicate: Predicate<PersistibleElement>, sortBy: SortDescriptor<PersistibleElement>?) async -> ResultElement?
 }
 
 extension PredicateReadableRepository {
@@ -99,6 +100,12 @@ public protocol SyncReadableRepository<Element> {
     var isEmpty: Bool { get }
     func find(query: (@Sendable (Element) -> Bool)?) -> [Element]
     func contains(element: Element) -> Bool
+}
+
+public protocol AsyncCheckRepository<Element> {
+    associatedtype Element: Equatable, Sendable
+    func isEmpty() async throws -> Bool
+    func count() async throws -> Int
 }
 
 public extension AsyncReadableRepository {

--- a/Sources/Repositories/SwiftData/SwiftDataRepository.swift
+++ b/Sources/Repositories/SwiftData/SwiftDataRepository.swift
@@ -73,7 +73,6 @@ extension SwiftDataRepository: AsyncBatchRepository {
         }
         try modelContext.save()
     }
-    
 }
 
 extension SwiftDataRepository: AsyncPredicableReadableRepository {
@@ -88,5 +87,27 @@ extension SwiftDataRepository: AsyncPredicableReadableRepository {
         guard let results = try? modelContext.fetch(descriptor) else { return [] }
         let mappedResults = results.map { Element(from: $0) }
         return mappedResults
+    }
+    
+    public func findFirst(predicate: Predicate<Element.SwiftDataEntity>, sortBy: SortDescriptor<Element.SwiftDataEntity>?) async -> Element? {
+        var descriptor = FetchDescriptor<Element.SwiftDataEntity>.init(predicate: predicate)
+        if let sortBy = sortBy {
+            descriptor.sortBy = [sortBy]
+        }
+        descriptor.fetchLimit = 1
+        guard let results = try? modelContext.fetch(descriptor) else { return nil }
+        let mappedResults = results.map { Element(from: $0) }
+        return mappedResults.count > 0 ? mappedResults[0] : nil
+    }
+}
+
+extension SwiftDataRepository: AsyncCheckRepository {
+    public func isEmpty() async throws -> Bool {
+        return try await count() == 0
+    }
+    
+    public func count() async throws -> Int {
+        let descriptor = FetchDescriptor<Element.SwiftDataEntity>()
+        return try modelContext.fetchCount(descriptor)
     }
 }

--- a/Tests/Repositories/SwiftData/SwiftDataRepositoryTests.swift
+++ b/Tests/Repositories/SwiftData/SwiftDataRepositoryTests.swift
@@ -124,6 +124,55 @@ struct SwiftDataRepositoryTests {
         #expect(result.count == 1)
     }
     
+    @Test func test_findFirstWithPredicate_expectCorrectResult() async throws {
+        let (sut, _) = try makeSUT()
+        let elements = [TestEntityV2(id: UUID(), name: "some name", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 2", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 3", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 4", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 5", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 6", createdAt: Date())]
+        try await sut.add(elements: elements)
+        
+        let predicate = #Predicate<TestSwiftDataEntity> { record in
+            record.name == "some name 5"
+        }
+        let sortBy = SortDescriptor<TestSwiftDataEntity>(\.name, order: .forward)
+        let result = await sut.findFirst(predicate: predicate, sortBy: sortBy)
+        
+        #expect(result != nil)
+    }
+    
+    @Test func test_count_expectCorrectResult() async throws {
+        let (sut, _) = try makeSUT()
+        let elements = [TestEntityV2(id: UUID(), name: "some name", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 2", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 3", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 4", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 5", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 6", createdAt: Date())]
+        try await sut.add(elements: elements)
+        
+        let result = try await sut.count()
+        
+        #expect(result == 6)
+    }
+    
+    @Test func test_isEmpty_expectCorrectResult() async throws {
+        let (sut, _) = try makeSUT()
+        let elements = [TestEntityV2(id: UUID(), name: "some name", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 2", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 3", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 4", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 5", createdAt: Date()),
+                        TestEntityV2(id: UUID(), name: "some name 6", createdAt: Date())]
+        try await sut.add(elements: elements)
+        
+        let result = try await sut.isEmpty()
+        
+        #expect(result == false)
+    }
+    
     func makeSUT() throws -> (SwiftDataRepository<TestEntityV2>, ModelContainer) {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: TestSwiftDataEntity.self, configurations: config)


### PR DESCRIPTION
### 📝 **What**
Implement three highly optimized, asynchronous data retrieval functions (count(), isEmpty(), and findFirst()) within the SwiftDataRepository layer. These methods must fetch metadata or single-record boundaries directly from the database engine without pulling full, unrestricted object graphs or complete collections into memory.
### 🎯 **Why**
Currently, verifying cache viability or inspecting the state of saved records forces our data providers to execute full table fetches. This wastes CPU cycles, thrashing memory allocations, and slowing down critical path execution.By adding lightweight metadata checks (count/isEmpty) and a short-circuit lookup (findFirst), higher-level components (such as our data providers and cache managers) can instantly evaluate data presence or peak into cached payloads. This optimizes cache miss paths and dramatically decreases application latency.
### **🛠 How**

- Implement the new methods within our ModelActor-based repository layer.

- Expose all three methods in the repository protocol signature as async throws to support modern Swift Concurrency isolation boundaries.

- Inside the implementations, apply strict optimization parameters to the FetchDescriptor:
- count():Invoke try modelContext.fetchCount(descriptor) directly to offload the counting optimization natively to the SQLite kernel.
- isEmpty(): Short-circuit the evaluation by forcing a fetchLimit = 1 constraint on the descriptor. If the returned array is empty, return true.
- findFirst(): Apply a strict fetchLimit = 1 constraint to fetch only the first record matching an optional predicate. Map the result into an immutable, thread-safe DTO before returning it across the actor boundary.

### 🔍 Acceptance Criteria
### AC 1: Protocol Signature & Concurrency Compliance
Given the public repository interface domain
When the pipeline compiles under strict Swift 6 Concurrency checking
Then count(), isEmpty(), and findFirst() must be explicitly marked as async throws to enforce clean, non-blocking actor thread-hopping boundaries.
### AC 2: Highly Optimized Count Check
Given a repository containing populated database records
When count() is called by a detached context
Then it must utilize modelContext.fetchCount to return the precise table size instantly without allocating memory for model object graphs.
### AC 3: Short-Circuited Empty State Evaluation
Given an empty or fully populated database table
When isEmpty() is executed by a caller
Then it must apply a fetchLimit = 1 constraint to evaluate the empty boolean state immediately, ensuring performance remains O(1) regardless of table scale.
### AC 4: Short-Circuited First Record Lookup
Given a repository with multiple saved records
When findFirst() is executed with an optional predicate
Then it must cap database I/O to a maximum of 1 record via fetchLimit = 1 and map that single entity into a thread-safe Sendable DTO before leaving the actor context.
### AC 5: Zero Cross-Isolation Data Races
Given active concurrent background workers
When these three methods are called simultaneously with write operations
Then execution must map sequentially onto the ModelActor's serial executor queue, ensuring full thread safety and zero multi-threaded database access collisions.